### PR TITLE
Fix: Enhance WatchdogService robustness against permission revocation

### DIFF
--- a/app/src/main/java/dev/hossain/keepalive/util/NotificationHelper.kt
+++ b/app/src/main/java/dev/hossain/keepalive/util/NotificationHelper.kt
@@ -50,4 +50,36 @@ class NotificationHelper(private val context: Context) {
             .setOngoing(true)
             .build()
     }
+
+    /**
+     * Updates an existing notification with a new title and content text.
+     *
+     * @param notificationId The ID of the notification to update.
+     * @param title The new title for the notification.
+     * @param contentText The new content text for the notification.
+     */
+    fun updateNotification(
+        notificationId: Int,
+        title: String,
+        contentText: String,
+    ) {
+        Timber.d("updateNotification() called with title: $title, contentText: $contentText")
+
+        val notificationIntent = Intent(context, MainActivity::class.java)
+        val pendingIntent =
+            PendingIntent.getActivity(context, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE)
+
+        val newNotification =
+            NotificationCompat.Builder(context, CHANNEL_ID)
+                .setContentTitle(title)
+                .setContentText(contentText)
+                .setSmallIcon(R.drawable.baseline_radar_24)
+                .setContentIntent(pendingIntent)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setOngoing(true)
+                .build()
+
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.notify(notificationId, newNotification)
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/hossain-khan/android-keep-alive/issues/102
* https://github.com/hossain-khan/android-keep-alive/issues/102

The WatchdogService could previously crash if the PACKAGE_USAGE_STATS permission was revoked during its operation, as it relied on this permission to check the status of monitored apps.

This commit introduces the following changes:
- Adds a runtime check for the PACKAGE_USAGE_STATS permission within the main loop of WatchdogService before attempting to query app usage.
- If the permission is found to be missing, the service now:
    - Logs a warning.
    - Updates its foreground notification to inform you that the permission is required and needs to be re-granted. This allows the service to remain active instead of crashing.
    - Skips the app monitoring cycle for that iteration.
- If the permission is present (or has been re-granted), the service ensures its notification is set to the default operational message.
- The NotificationHelper class was updated with a new method `updateNotification` to allow changing the foreground notification's content dynamically.
- Added inline comments and KDoc to document the new logic.

These changes make the WatchdogService more resilient to permission changes, improving its stability and your communication when critical permissions are missing.