### PR TITLE
Refactor: Use early return for permission check in WatchdogService

### DIFF
--- a/app/src/main/java/dev/hossain/keepalive/util/NotificationHelper.kt
+++ b/app/src/main/java/dev/hossain/keepalive/util/NotificationHelper.kt
@@ -50,4 +50,36 @@ class NotificationHelper(private val context: Context) {
             .setOngoing(true)
             .build()
     }
+
+    /**
+     * Updates an existing notification with a new title and content text.
+     *
+     * @param notificationId The ID of the notification to update.
+     * @param title The new title for the notification.
+     * @param contentText The new content text for the notification.
+     */
+    fun updateNotification(
+        notificationId: Int,
+        title: String,
+        contentText: String,
+    ) {
+        Timber.d("updateNotification() called with title: $title, contentText: $contentText")
+
+        val notificationIntent = Intent(context, MainActivity::class.java)
+        val pendingIntent =
+            PendingIntent.getActivity(context, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE)
+
+        val newNotification =
+            NotificationCompat.Builder(context, CHANNEL_ID)
+                .setContentTitle(title)
+                .setContentText(contentText)
+                .setSmallIcon(R.drawable.baseline_radar_24)
+                .setContentIntent(pendingIntent)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setOngoing(true)
+                .build()
+
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.notify(notificationId, newNotification)
+    }
 }


### PR DESCRIPTION
Refinement from:
* https://github.com/hossain-khan/android-keep-alive/pull/103

--- 

I've refactored the WatchdogService to use an early return (guard clause) for the PACKAGE_USAGE_STATS permission check within its main monitoring loop.

Previously, the permission check used an if/else structure. The new approach inverts the condition to check if the permission is *not* granted. If so, it updates your notification, logs a warning, and then uses `continue` to skip the remainder of the loop iteration. The main delay at the beginning of the loop governs the re-check frequency.

This change improves code readability by reducing nesting for the primary logic path (when permission is granted). Comments have been reviewed and updated to align with this new structure.