### PR TITLE
Add KDoc documentation to classes in the data package

### DIFF
--- a/app/src/main/java/dev/hossain/keepalive/data/AirtableConfig.kt
+++ b/app/src/main/java/dev/hossain/keepalive/data/AirtableConfig.kt
@@ -2,12 +2,18 @@ package dev.hossain.keepalive.data
 
 import dev.hossain.keepalive.util.Validator.isValidUrl
 
+/**
+ * Represents the configuration for Airtable integration.
+ */
 data class AirtableConfig(
     val isEnabled: Boolean,
     val token: String,
     val dataUrl: String,
 ) {
-    // Check if the Airtable configuration is valid
+    /**
+     * Checks if the Airtable configuration is valid, ensuring that the feature is enabled,
+     * a token is present, and the data URL is a valid URL format.
+     */
     fun isValid(): Boolean {
         return isEnabled && token.isNotBlank() && isValidUrl(dataUrl)
     }

--- a/app/src/main/java/dev/hossain/keepalive/data/AppDataStore.kt
+++ b/app/src/main/java/dev/hossain/keepalive/data/AppDataStore.kt
@@ -9,9 +9,16 @@ import dev.hossain.keepalive.ui.screen.AppListSerializer
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
+/**
+ * Provides a DataStore for persisting a list of `AppInfo` objects.
+ */
 object AppDataStore {
     lateinit var dataStore: DataStore<List<AppInfo>>
 
+    /**
+     * Initializes and returns the DataStore instance.
+     * If already initialized, returns the existing instance.
+     */
     fun store(context: Context): DataStore<List<AppInfo>> {
         if (!::dataStore.isInitialized) {
             dataStore = createDataStore(context)
@@ -20,6 +27,9 @@ object AppDataStore {
         return dataStore
     }
 
+    /**
+     * Creates a new DataStore instance for storing `AppInfo` objects.
+     */
     private fun createDataStore(context: Context): DataStore<List<AppInfo>> {
         return DataStoreFactory.create(
             serializer = AppListSerializer,

--- a/app/src/main/java/dev/hossain/keepalive/data/PermissionType.kt
+++ b/app/src/main/java/dev/hossain/keepalive/data/PermissionType.kt
@@ -1,7 +1,7 @@
 package dev.hossain.keepalive.data
 
 /**
- * Only contains the permission that are requested at runtime.
+ * Defines the types of runtime permissions that the application may request from the user.
  *
  * See additional permissions in AndroidManifest.xml
  *

--- a/app/src/main/java/dev/hossain/keepalive/data/SettingsRepository.kt
+++ b/app/src/main/java/dev/hossain/keepalive/data/SettingsRepository.kt
@@ -14,6 +14,9 @@ import kotlinx.coroutines.flow.map
 // Define keys for the preferences
 private val Context.dataStore by preferencesDataStore(name = "app_settings")
 
+/**
+ * Manages application settings using DataStore.
+ */
 class SettingsRepository(private val context: Context) {
     companion object {
         val APP_CHECK_INTERVAL = intPreferencesKey("app_check_interval")
@@ -25,7 +28,9 @@ class SettingsRepository(private val context: Context) {
         val AIRTABLE_DATA_URL = stringPreferencesKey("airtable_data_url")
     }
 
-    // Retrieve app check interval from DataStore
+    /**
+     * Flow representing the app check interval in minutes.
+     */
     val appCheckIntervalFlow: Flow<Int> =
         context.dataStore.data
             .map { preferences ->
@@ -33,49 +38,63 @@ class SettingsRepository(private val context: Context) {
                 if (interval < MINIMUM_APP_CHECK_INTERVAL_MIN) MINIMUM_APP_CHECK_INTERVAL_MIN else interval
             }
 
-    // Retrieve force start apps enabled state from DataStore
+    /**
+     * Flow representing whether force starting apps is enabled.
+     */
     val enableForceStartAppsFlow: Flow<Boolean> =
         context.dataStore.data
             .map { preferences ->
                 preferences[ENABLE_FORCE_START_APPS] ?: false // Default to disabled
             }
 
-    // Retrieve health check enabled state from DataStore
+    /**
+     * Flow representing whether health check is enabled.
+     */
     val enableHealthCheckFlow: Flow<Boolean> =
         context.dataStore.data
             .map { preferences ->
                 preferences[ENABLE_HEALTH_CHECK] ?: false // Default to disabled
             }
 
-    // Retrieve health check UUID from DataStore
+    /**
+     * Flow representing the health check UUID.
+     */
     val healthCheckUUIDFlow: Flow<String> =
         context.dataStore.data
             .map { preferences ->
                 preferences[HEALTH_CHECK_UUID] ?: "" // Default to empty string
             }
 
-    // Retrieve remote logging enabled state from DataStore
+    /**
+     * Flow representing whether remote logging is enabled.
+     */
     val enableRemoteLoggingFlow: Flow<Boolean> =
         context.dataStore.data
             .map { preferences ->
                 preferences[ENABLE_REMOTE_LOGGING] ?: false // Default to disabled
             }
 
-    // Retrieve Airtable token from DataStore
+    /**
+     * Flow representing the Airtable token.
+     */
     val airtableTokenFlow: Flow<String> =
         context.dataStore.data
             .map { preferences ->
                 preferences[AIRTABLE_TOKEN] ?: "" // Default to empty string
             }
 
-    // Retrieve Airtable data URL from DataStore
+    /**
+     * Flow representing the Airtable data URL.
+     */
     val airtableDataUrlFlow: Flow<String> =
         context.dataStore.data
             .map { preferences ->
                 preferences[AIRTABLE_DATA_URL] ?: "" // Default to empty string
             }
 
-    // Combine remote logging enabled state, Airtable token, and Airtable data URL from DataStore
+    /**
+     * Flow representing the Airtable configuration.
+     */
     val airtableConfig: Flow<AirtableConfig> =
         combine(
             enableRemoteLoggingFlow,
@@ -85,43 +104,63 @@ class SettingsRepository(private val context: Context) {
             AirtableConfig(isRemoteLoggingEnabled, airtableToken, airtableDataUrl)
         }
 
-    // Save values in DataStore
+    /**
+     * Saves the app check interval in minutes.
+     */
     suspend fun saveAppCheckInterval(interval: Int) {
         context.dataStore.edit { preferences ->
             preferences[APP_CHECK_INTERVAL] = interval
         }
     }
 
+    /**
+     * Saves whether force starting apps is enabled.
+     */
     suspend fun saveEnableForceStartApps(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[ENABLE_FORCE_START_APPS] = enabled
         }
     }
 
+    /**
+     * Saves whether health check is enabled.
+     */
     suspend fun saveEnableHealthCheck(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[ENABLE_HEALTH_CHECK] = enabled
         }
     }
 
+    /**
+     * Saves the health check UUID.
+     */
     suspend fun saveHealthCheckUUID(uuid: String) {
         context.dataStore.edit { preferences ->
             preferences[HEALTH_CHECK_UUID] = uuid
         }
     }
 
+    /**
+     * Saves whether remote logging is enabled.
+     */
     suspend fun saveEnableRemoteLogging(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[ENABLE_REMOTE_LOGGING] = enabled
         }
     }
 
+    /**
+     * Saves the Airtable token.
+     */
     suspend fun saveAirtableToken(token: String) {
         context.dataStore.edit { preferences ->
             preferences[AIRTABLE_TOKEN] = token
         }
     }
 
+    /**
+     * Saves the Airtable data URL.
+     */
     suspend fun saveAirtableDataUrl(url: String) {
         context.dataStore.edit { preferences ->
             preferences[AIRTABLE_DATA_URL] = url


### PR DESCRIPTION
This commit adds KDoc documentation to the following classes:
- AirtableConfig.kt
- AppDataStore.kt
- PermissionType.kt
- SettingsRepository.kt

The documentation includes class summaries and explanations for public methods and properties, improving code readability and maintainability.