### PR TITLE
[UPDATE] Use pass for signing

### DIFF
--- a/.github/workflows/test-keystore-apk-signing.yml
+++ b/.github/workflows/test-keystore-apk-signing.yml
@@ -69,16 +69,17 @@ jobs:
           echo "Test content" > keystore-test/test.txt
           jar cf keystore-test/test.jar keystore-test/test.txt
           
-          # Test signing WITHOUT -keypass (the working approach)
-          echo "Testing jarsigner without explicit key password..."
+          # Test signing WITH explicit key password (required for PKCS12)
+          echo "Testing jarsigner with explicit key password..."
           if jarsigner -keystore keystore-test/release.keystore \
                       -storepass "${{ secrets.KEYSTORE_PASSWORD }}" \
+                      -keypass "${{ secrets.KEY_PASSWORD }}" \
                       keystore-test/test.jar \
                       "${{ secrets.KEY_ALIAS }}" > keystore-test/jarsigner.txt 2>&1; then
-            echo "✅ jarsigner succeeded (store password used for both store and key)"
+            echo "✅ jarsigner succeeded (store and key password provided)"
             echo "✅ This confirms the keystore is compatible with our build configuration"
           else
-            echo "❌ jarsigner failed even without explicit key password"
+            echo "❌ jarsigner failed even with explicit key password"
             cat keystore-test/jarsigner.txt
             exit 1
           fi


### PR DESCRIPTION
Potentially fixes 

```
=== Testing jarsigner ===
Testing jarsigner without explicit key password...
❌ jarsigner failed even without explicit key password
Enter key password for ***: jarsigner: you must enter key password
Error: Process completed with exit code 1.
```