### PR TITLE
Feat: Implement Bottom Navigation Bar

### DIFF
--- a/app/src/main/java/dev/hossain/keepalive/MainActivity.kt
+++ b/app/src/main/java/dev/hossain/keepalive/MainActivity.kt
@@ -12,14 +12,6 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Surface
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.List
@@ -29,8 +21,16 @@ import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -253,14 +253,18 @@ fun MainAppScreen(
                 // For now, using MainLandingScreen without permission UI.
                 MainLandingScreen(
                     navController = navController,
-                    allPermissionsGranted = true, // Assuming all permissions are granted here
+                    // Assuming all permissions are granted here
+                    allPermissionsGranted = true,
                     activityResultLauncher = null,
                     requestPermissionLauncher = null,
-                    permissionType = PERMISSION_POST_NOTIFICATIONS, // Dummy value
-                    showPermissionRequestDialog = remember { mutableStateOf(false) }, // Dummy value
+                    // Dummy value
+                    permissionType = PERMISSION_POST_NOTIFICATIONS,
+                    // Dummy value
+                    showPermissionRequestDialog = remember { mutableStateOf(false) },
                     onRequestPermissions = {},
                     totalRequiredCount = mainViewModel.totalPermissionRequired,
-                    grantedCount = mainViewModel.totalPermissionRequired, // Assuming all granted
+                    // Assuming all granted
+                    grantedCount = mainViewModel.totalPermissionRequired,
                     configuredAppsCount = configuredAppsCount,
                 )
             }

--- a/app/src/main/java/dev/hossain/keepalive/ui/screen/MainScreen.kt
+++ b/app/src/main/java/dev/hossain/keepalive/ui/screen/MainScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import dev.hossain.keepalive.R
 import dev.hossain.keepalive.data.PermissionType
-import dev.hossain.keepalive.ui.Screen
 import dev.hossain.keepalive.ui.theme.KeepAliveTheme
 
 /**

--- a/app/src/main/java/dev/hossain/keepalive/ui/screen/MainScreen.kt
+++ b/app/src/main/java/dev/hossain/keepalive/ui/screen/MainScreen.kt
@@ -140,21 +140,15 @@ fun MainLandingScreen(
                         verticalArrangement = Arrangement.Center,
                         horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
-                        Button(
-                            onClick = { navController.navigate(Screen.AppSettings.route) },
-                        ) {
-                            Text("Configure Immortal Apps")
-                        }
-
                         // Display subtitle with appropriate text based on configured app count
                         Text(
                             text =
                                 if (configuredAppsCount == 0) {
-                                    "No app added to watch list"
+                                    "No app added to watch list. \nGo to 'App Settings' to add apps."
                                 } else {
                                     "Watching $configuredAppsCount apps"
                                 },
-                            style = MaterialTheme.typography.bodySmall,
+                            style = MaterialTheme.typography.bodyLarge,
                             color =
                                 if (configuredAppsCount == 0) {
                                     MaterialTheme.colorScheme.error
@@ -164,19 +158,6 @@ fun MainLandingScreen(
                             textAlign = TextAlign.Center,
                             modifier = Modifier.padding(top = 2.dp),
                         )
-
-                        Button(
-                            onClick = { navController.navigate(Screen.AppConfigs.route) },
-                            modifier = Modifier.padding(top = 8.dp),
-                        ) {
-                            Text("App Configurations")
-                        }
-                        Button(
-                            onClick = { navController.navigate(Screen.ActivityLogs.route) },
-                            modifier = Modifier.padding(top = 8.dp),
-                        ) {
-                            Text("Monitor Activity")
-                        }
                     }
                 }
             }


### PR DESCRIPTION
- Replaced button-based navigation with a Material 3 BottomAppBar after permissions are granted.
- MainActivity now conditionally shows MainLandingScreen (for permissions) or MainAppScreen (with bottom navigation).
- Updated MainScreen to remove old navigation buttons.
- Added icons for each screen in the bottom navigation.