### PR TITLE
[ADDED] App watch badge and proper naming

### DIFF
--- a/app/src/main/java/dev/hossain/keepalive/ui/BottomNavigationWrapper.kt
+++ b/app/src/main/java/dev/hossain/keepalive/ui/BottomNavigationWrapper.kt
@@ -4,7 +4,12 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
@@ -13,6 +18,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -40,7 +51,10 @@ fun BottomNavigationWrapper(
     Scaffold(
         bottomBar = {
             if (allPermissionsGranted) {
-                BottomNavigationBar(navController = navController)
+                BottomNavigationBar(
+                    navController = navController,
+                    configuredAppsCount = configuredAppsCount,
+                )
             }
         },
     ) { innerPadding ->
@@ -63,13 +77,13 @@ fun BottomNavigationWrapper(
                     configuredAppsCount = configuredAppsCount,
                 )
             }
-            composable(Screen.AppConfigs.route) {
+            composable(Screen.WatchDogConfig.route) {
                 AppConfigScreen(
                     navController,
                     context,
                 )
             }
-            composable(Screen.AppSettings.route) {
+            composable(Screen.AppWatchList.route) {
                 SettingsScreen(navController)
             }
             composable(Screen.ActivityLogs.route) {
@@ -83,12 +97,15 @@ fun BottomNavigationWrapper(
 }
 
 @Composable
-fun BottomNavigationBar(navController: NavHostController) {
+fun BottomNavigationBar(
+    navController: NavHostController,
+    configuredAppsCount: Int,
+) {
     val items =
         listOf(
             Screen.Home,
-            Screen.AppSettings,
-            Screen.AppConfigs,
+            Screen.AppWatchList,
+            Screen.WatchDogConfig,
             Screen.ActivityLogs,
         )
 
@@ -98,7 +115,34 @@ fun BottomNavigationBar(navController: NavHostController) {
     NavigationBar {
         items.forEach { screen ->
             NavigationBarItem(
-                icon = { Icon(screen.icon, contentDescription = screen.title) },
+                icon = {
+                    BadgedBox(
+                        badge = {
+                            if (screen == Screen.AppWatchList && configuredAppsCount > 0) {
+                                Badge(
+                                    modifier =
+                                        Modifier
+                                            .size(20.dp)
+                                            .clip(CircleShape),
+                                    containerColor = MaterialTheme.colorScheme.primary,
+                                    contentColor = Color.White,
+                                ) {
+                                    Text(
+                                        text = configuredAppsCount.toString(),
+                                        fontSize = 12.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        textAlign = TextAlign.Center,
+                                        modifier = Modifier.padding(4.dp),
+                                    )
+                                }
+                            } else {
+                                null
+                            }
+                        },
+                    ) {
+                        Icon(screen.icon, contentDescription = screen.title)
+                    }
+                },
                 label = { Text(screen.title) },
                 selected = currentRoute == screen.route,
                 onClick = {

--- a/app/src/main/java/dev/hossain/keepalive/ui/Screen.kt
+++ b/app/src/main/java/dev/hossain/keepalive/ui/Screen.kt
@@ -7,13 +7,27 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
 
+/**
+ * Represents the different screens in the app for navigation.
+ *
+ * @property route The navigation route for the screen.
+ * @property title The display title of the screen.
+ * @property icon The icon associated with the screen.
+ */
 enum class Screen(
     val route: String,
     val title: String,
     val icon: ImageVector,
 ) {
+    /** Home screen of the app. */
     Home("home", "Home", Icons.Filled.Home),
-    AppConfigs("app_configs", "Config", Icons.Filled.Settings),
-    AppSettings("settings", "Apps", Icons.AutoMirrored.Filled.List),
+
+    /** Screen for managing app configurations. */
+    WatchDogConfig("app_configs", "Config", Icons.Filled.Settings),
+
+    /** Screen displaying the list of apps that are watched. */
+    AppWatchList("app_watch_list", "Apps", Icons.AutoMirrored.Filled.List),
+
+    /** Screen showing activity logs. */
     ActivityLogs("activity_logs", "Logs", Icons.Filled.Info),
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `BottomNavigationWrapper` and `Screen` components in the app's UI. The changes improve navigation clarity, add visual indicators for the app watch list, and update the screen definitions for better alignment with their purposes.

### Updates to `BottomNavigationWrapper`:

* **Added badge for app watch list:** The `BottomNavigationBar` now includes a badge displaying the count of configured apps when the app watch list is selected. This badge is styled with a circular shape, primary color, and bold text for better visibility. (`[app/src/main/java/dev/hossain/keepalive/ui/BottomNavigationWrapper.ktL101-R145](diffhunk://#diff-bd092917ae31db8ab03543b3b6278c6a8ee8a9ce7f3da1660d018dc10ea94e8bL101-R145)`)
* **Updated navigation routes:** Replaced `Screen.AppConfigs` with `Screen.WatchDogConfig` and `Screen.AppSettings` with `Screen.AppWatchList` to better reflect their functionalities. (`[[1]](diffhunk://#diff-bd092917ae31db8ab03543b3b6278c6a8ee8a9ce7f3da1660d018dc10ea94e8bL66-R86)`, `[[2]](diffhunk://#diff-bd092917ae31db8ab03543b3b6278c6a8ee8a9ce7f3da1660d018dc10ea94e8bL86-R108)`)

### Updates to `Screen` definitions:

* **Refactored screen names and descriptions:** Renamed `AppConfigs` to `WatchDogConfig` and `AppSettings` to `AppWatchList`. Added detailed comments to clarify the purpose of each screen in the `Screen` enum. (`[app/src/main/java/dev/hossain/keepalive/ui/Screen.ktR10-R31](diffhunk://#diff-9a61c4f2e2563cf95fafb3e9d4f7c0c0863fa38f59839f4de56d40e580456555R10-R31)`)