### PR TITLE
Add GitHub workflow to build and release signed APK

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,57 @@
+name: Android Release APK
+
+on:
+  push:
+    tags:
+      - 'v*.*'
+
+jobs:
+  build-and-release:
+    name: Build and Release APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Decode Keystore
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          echo $RELEASE_KEYSTORE_BASE64 | base64 --decode > ${{ github.workspace }}/release.keystore
+
+      - name: Get Version Name
+        id: get_version
+        run: echo "VERSION_NAME=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Build Release APK
+        env:
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          ./gradlew assembleRelease \
+            -Pandroid.injected.signing.store.file=${{ github.workspace }}/release.keystore \
+            -Pandroid.injected.signing.store.password=$RELEASE_KEYSTORE_PASSWORD \
+            -Pandroid.injected.signing.key.alias=$RELEASE_KEY_ALIAS \
+            -Pandroid.injected.signing.key.password=$RELEASE_KEY_PASSWORD
+
+      - name: Rename APK
+        run: |
+          VERSION_NAME=$(echo $GITHUB_REF | sed 's/refs\/tags\/v//')
+          mv app/build/outputs/apk/release/app-release.apk keep-alive-release-v$VERSION_NAME.apk
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: keep-alive-release-v*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow automates the process of:
- Triggering on new tags (e.g., v1.0).
- Building a signed release APK using secrets for keystore information.
- Naming the APK with the version from the tag (e.g., keep-alive-release-v1.0.apk).
- Uploading the generated APK as an asset to the GitHub release.


Alternative to:
* https://github.com/hossain-khan/android-keep-alive/pull/130