### PR TITLE
Document Android 16 limitations and cite API35 warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This app is designed with a very specific use case in mind. It is important to u
 
 ### Limitations 💔
 Despite having many needed permissions, this app may still not work due to the strict security of Android. 
+* Android 16 (API 36) and newer releases are **not supported** because their expanded background-start and overlay restrictions prevent the watchdog foreground service from reliably launching other apps; testing shows the core use case fails.
 * One known issue is related to receiving `RECEIVE_BOOT_COMPLETED` event that is needed to start the watchdog service of this app. However, the `RECEIVE_BOOT_COMPLETED` event is not delivered until user unlocks the device after phone is restarted or incase phone got soft-started because of very low memory pressure.
   * In that case, this "Keep Alive" app will fail to start configured apps until the device is unlocked manually. (See https://github.com/hossain-khan/android-keep-alive/issues/70 for technical details)
 * Another known issue is, even though foreground service is running, it does not trigger the periodic checks based on your configured interval. I have noticed this happen in Samsung Galaxy S23, on other phone it works. So, there might be some bug or manufacturer or device specific issue. Take a look into "Monitor Activity" to see how checks are doing.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,6 +31,7 @@ android {
          * your app already has an active overlay window before it attempts to start a foreground service from the background.
          * You can check if your overlay window is currently visible by calling View.getWindowVisibility(),
          * or you can override View.onWindowVisibilityChanged() to get notified whenever the visibility changes.
+         * Reference: https://developer.android.com/about/versions/15/behavior-changes-15#bg-starts
          */
         targetSdk = 34 // Android 15 (Vanilla Ice Cream)
         versionCode = 19


### PR DESCRIPTION
## Summary
- add the official Android 15 behavior-change reference to the targetSdk warning comment
- explicitly document in the README that Android 16 (API 36) and newer are unsupported because the watchdog can no longer launch apps reliably

## Testing
- not applicable (docs-only change)