### PR TITLE
Fix release workflow 403 error by adding contents write permission

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -25,6 +25,8 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to upload assets to releases
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem
Release workflow was failing with 403 error when trying to upload APK to GitHub releases:
```
❌ Failed to upload APK (HTTP 403)
{"message":"Resource not accessible by integration"...}
```

## Solution
Added explicit `contents: write` permission to the workflow job. The default `GITHUB_TOKEN` has read-only permissions for the `release` event, which prevents uploading release assets.

## Changes
- Added `permissions: contents: write` to `build-and-release` job

## Testing
- This will be verified on the next release tag