### PR TITLE
Fix: Add App buttons cutoff on Configure Apps screen (#205)

### DIFF
--- a/app/src/main/java/dev/hossain/keepalive/MainActivity.kt
+++ b/app/src/main/java/dev/hossain/keepalive/MainActivity.kt
@@ -8,6 +8,7 @@ import android.provider.Settings
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -75,6 +76,7 @@ class MainActivity : ComponentActivity() {
      */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
 
         setContent {
             // Observe theme preference

--- a/app/src/main/java/dev/hossain/keepalive/MainActivity.kt
+++ b/app/src/main/java/dev/hossain/keepalive/MainActivity.kt
@@ -76,6 +76,11 @@ class MainActivity : ComponentActivity() {
      */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Edge-to-edge: allows app content to draw behind the status bar and navigation bar.
+        // System bar insets are consumed by the top-level Scaffold in BottomNavigationWrapper
+        // via Modifier.padding(innerPadding), so individual screens do not need to handle them.
+        // NOTE: If a screen is ever shown outside of BottomNavigationWrapper (e.g. a standalone
+        // Activity or dialog-style flow), it must handle WindowInsets itself.
         enableEdgeToEdge()
 
         setContent {

--- a/app/src/main/java/dev/hossain/keepalive/ui/BottomNavigationWrapper.kt
+++ b/app/src/main/java/dev/hossain/keepalive/ui/BottomNavigationWrapper.kt
@@ -47,6 +47,10 @@ fun BottomNavigationWrapper(
     lastCheckTime: Long = 0L,
     serviceStartTime: Long = 0L,
 ) {
+    // Edge-to-edge: this top-level Scaffold is the single source of truth for system bar insets.
+    // Its innerPadding includes status bar (top) and navigation bar (bottom) insets.
+    // Passing innerPadding to the NavHost via Modifier.padding(innerPadding) ensures all
+    // nested screens are automatically inset-safe without needing individual WindowInsets handling.
     Scaffold(
         bottomBar = {
             if (allPermissionsGranted) {

--- a/app/src/main/java/dev/hossain/keepalive/ui/screen/AppListSettings.kt
+++ b/app/src/main/java/dev/hossain/keepalive/ui/screen/AppListSettings.kt
@@ -104,7 +104,7 @@ fun AppListScreen(
 ) {
     val appList by viewModel.appList.observeAsState(emptyList())
     val selectedApps by viewModel.selectedApps.observeAsState(emptySet())
-    val installedApps = viewModel.getInstalledApps(context)
+    val installedApps = remember(context) { viewModel.getInstalledApps(context) }
     val showDialog = remember { mutableStateOf(false) }
     val showDeleteDialog = remember { mutableStateOf<AppInfo?>(null) }
     val coroutineScope = rememberCoroutineScope()

--- a/app/src/main/java/dev/hossain/keepalive/ui/screen/AppListSettings.kt
+++ b/app/src/main/java/dev/hossain/keepalive/ui/screen/AppListSettings.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -112,22 +111,26 @@ fun AppListScreen(
     val view = LocalView.current
 
     Column(modifier = modifier) {
-        Text(
-            text = "Apps that are kept running:",
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(vertical = 8.dp),
-        )
-        Text(
-            text =
-                "These apps will be periodically checked if they were recently run, " +
-                    "if not, they will be restarted based on app configuration you choose.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        LazyColumn {
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            item {
+                Text(
+                    text = "Apps that are kept running:",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
+            }
+            item {
+                Text(
+                    text =
+                        "These apps will be periodically checked if they were recently run, " +
+                            "if not, they will be restarted based on app configuration you choose.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+            }
             if (appList.isEmpty()) {
                 item {
                     Column(
@@ -178,29 +181,28 @@ fun AppListScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Button(
-            onClick = {
-                view.performHapticFeedback(HapticFeedbackConstants.CONTEXT_CLICK)
-                showDialog.value = true
-            },
-            modifier =
-                Modifier
-                    .wrapContentWidth()
-                    .align(Alignment.CenterHorizontally),
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text("Add App")
-                Text("Add a new app to the watchlist.", style = MaterialTheme.typography.labelSmall)
+            Button(
+                onClick = {
+                    view.performHapticFeedback(HapticFeedbackConstants.CONTEXT_CLICK)
+                    showDialog.value = true
+                },
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("Add App")
+                    Text("Add a new app to the watchlist.", style = MaterialTheme.typography.labelSmall)
+                }
             }
-        }
 
-        Spacer(modifier = Modifier.height(8.dp))
-        // Done Button
-        Button(
-            onClick = { navController.popBackStack() },
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-        ) {
-            Text("Done")
+            Button(
+                onClick = { navController.popBackStack() },
+            ) {
+                Text("Done")
+            }
         }
 
         if (showDialog.value) {

--- a/app/src/main/java/dev/hossain/keepalive/ui/screen/AppViewModel.kt
+++ b/app/src/main/java/dev/hossain/keepalive/ui/screen/AppViewModel.kt
@@ -48,7 +48,7 @@ class AppViewModel(private val dataStore: DataStore<List<AppInfo>>) : ViewModel(
      */
     fun toggleAppSelection(appInfo: AppInfo) {
         _selectedApps.value =
-            _selectedApps.value?.toMutableSet()?.apply {
+            (_selectedApps.value ?: emptySet()).toMutableSet().apply {
                 if (contains(appInfo)) remove(appInfo) else add(appInfo)
             }
     }


### PR DESCRIPTION
Fixes #205 — "Add App buttons are cutoff on the Apps list" reported on OnePlus 13 (OxygenOS 16, 6.82" display).

Closes https://github.com/hossain-khan/android-keep-alive/pull/193

## Changes

### Bug Fix
- **`AppListSettings.kt`** — Applied `Modifier.weight(1f)` to the `LazyColumn` so the app list fills available vertical space and never pushes the action buttons off-screen.
- **`AppListSettings.kt`** — Moved the header texts ("Apps that are kept running:" and the description) inside the `LazyColumn` as `item {}` entries, freeing up fixed vertical space for the list.
- **`AppListSettings.kt`** — Combined the "Add App" and "Done" buttons into a single `Row`, reducing bottom area footprint and preventing them from being clipped on smaller available heights.
- **`MainActivity.kt`** — Enabled edge-to-edge display (`enableEdgeToEdge()`) so content correctly uses the full display area on large/modern devices.

### Optimizations
- **`AppListSettings.kt`** — Wrapped `getInstalledApps(context)` in `remember(context)` to avoid an expensive `PackageManager.getInstalledApplications()` call on every recomposition.
- **`AppViewModel.kt`** — Fixed a null safety issue in `toggleAppSelection()`: replaced the nullable chain `_selectedApps.value?.toMutableSet()` with `(_selectedApps.value ?: emptySet()).toMutableSet()` to prevent silent state loss.

### Documentation
- Added inline comments in `MainActivity.kt` and `BottomNavigationWrapper.kt` documenting the edge-to-edge inset strategy, explaining that `innerPadding` from the top-level `Scaffold` propagates to all nested screens via the `NavHost`.