### PR TITLE
[BUMP] Prepare for v2.9 release

### DIFF
--- a/RELEASE-PROCESS.md
+++ b/RELEASE-PROCESS.md
@@ -19,6 +19,14 @@ Before starting a release, ensure you have:
 
 ### 1. Prepare the Version
 
+> **Note:** Direct commits to `main` are not supported. All release preparation must be done on a dedicated release branch and merged via a Pull Request.
+
+Create a release branch from `main`:
+```bash
+git checkout main && git pull
+git checkout -b release/vX.Y
+```
+
 Update the version in `app/build.gradle.kts`:
 
 ```kotlin
@@ -26,12 +34,14 @@ versionCode = 17  // Increment by 1
 versionName = "2.3"  // Update semantic version
 ```
 
-Commit the version change:
+Commit the version change and push the branch:
 ```bash
 git add app/build.gradle.kts
 git commit -m "[BUMP] Prepare for v2.3 release"
-git push origin main
+git push origin release/v2.3
 ```
+
+Then open a PR from `release/v2.3` → `main` and merge it before proceeding.
 
 ### 2. Generate Changelog
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
          * Reference: https://developer.android.com/about/versions/15/behavior-changes-15#bg-starts
          */
         targetSdk = 34 // Android 15 (Vanilla Ice Cream)
-        versionCode = 22
-        versionName = "2.8"
+        versionCode = 23
+        versionName = "2.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## v2.9 Release Prep

Bumps `versionCode` 22 → 23 and `versionName` `2.8` → `2.9`.

---

## What's New since v2.7

### 🐛 Bug Fixes
- Fix buttons cutoff on Configure Apps screen — `Add App` and `Done` buttons were not visible on large-display devices like OnePlus 13 (#205, #206)

### 🔧 Improvements
- Enable edge-to-edge display support in `MainActivity`
- Move header texts inside `LazyColumn` for better space utilization on the Configure Apps screen
- Combine `Add App` and `Done` buttons into a single row to reduce bottom area footprint
- Memoize `getInstalledApps()` with `remember(context)` to avoid expensive `PackageManager` query on every recomposition
- Fix null safety in `AppViewModel.toggleAppSelection()` to prevent silent state loss

### 📝 Documentation
- Add inline comments documenting edge-to-edge inset strategy across `MainActivity` and `BottomNavigationWrapper`
- Update `RELEASE-PROCESS.md` to require a release branch + PR instead of direct commits to `main`
- Add `copilot-instructions.md` for Copilot coding agent onboarding (#204)

**Full Changelog**: https://github.com/hossain-khan/android-keep-alive/compare/v2.7...release/v2.9