### PR TITLE
feat: Add edge-to-edge support for adaptive system bar insets

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,7 +67,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.KeepALive">
+            android:theme="@style/Theme.KeepALive"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/dev/hossain/keepalive/MainActivity.kt
+++ b/app/src/main/java/dev/hossain/keepalive/MainActivity.kt
@@ -82,6 +82,7 @@ class MainActivity : ComponentActivity() {
         // NOTE: If a screen is ever shown outside of BottomNavigationWrapper (e.g. a standalone
         // Activity or dialog-style flow), it must handle WindowInsets itself.
         enableEdgeToEdge()
+        window.isNavigationBarContrastEnforced = false
 
         setContent {
             // Observe theme preference

--- a/app/src/main/java/dev/hossain/keepalive/ui/screen/AppActivityLogScreen.kt
+++ b/app/src/main/java/dev/hossain/keepalive/ui/screen/AppActivityLogScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -207,6 +208,7 @@ fun AppActivityLogScreen(
                 modifier =
                     Modifier
                         .fillMaxSize()
+                        .imePadding()
                         .padding(horizontal = 16.dp),
             ) {
                 // Search bar

--- a/app/src/main/java/dev/hossain/keepalive/ui/screen/AppAdditionalConfigs.kt
+++ b/app/src/main/java/dev/hossain/keepalive/ui/screen/AppAdditionalConfigs.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
@@ -107,6 +108,7 @@ fun AppConfigScreen(
                 Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
+                    .imePadding()
                     .padding(24.dp)
                     .verticalScroll(rememberScrollState()),
         ) {

--- a/app/src/main/java/dev/hossain/keepalive/ui/screen/AppListSettings.kt
+++ b/app/src/main/java/dev/hossain/keepalive/ui/screen/AppListSettings.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -111,7 +112,10 @@ fun AppListScreen(
     val view = LocalView.current
 
     Column(modifier = modifier) {
-        LazyColumn(modifier = Modifier.weight(1f)) {
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+            contentPadding = PaddingValues(horizontal = 24.dp),
+        ) {
             item {
                 Text(
                     text = "Apps that are kept running:",
@@ -182,7 +186,10 @@ fun AppListScreen(
         Spacer(modifier = Modifier.height(16.dp))
 
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
             verticalAlignment = Alignment.CenterVertically,
         ) {


### PR DESCRIPTION
## Overview
Migrate the Keep-Alive app to support edge-to-edge layout for better use of screen space.

## Changes
- Add `android:windowSoftInputMode='adjustResize'` to MainActivity in manifest
- Add `imePadding()` to TextFields in AppConfigScreen and AppActivityLogScreen
- Refactor AppListSettings LazyColumn to use contentPadding for proper nav bar spacing
- Set `window.isNavigationBarContrastEnforced = false` to prevent translucent background
- Ensures lists scroll behind navigation bar and TextFields aren't hidden by keyboard

## Testing
- ✅ ktlint checks passed
- ✅ assembleDebug successful
- ✅ All unit tests passed
- ✅ No compilation errors

## Files Changed
- app/src/main/AndroidManifest.xml
- app/src/main/java/dev/hossain/keepalive/MainActivity.kt
- app/src/main/java/dev/hossain/keepalive/ui/screen/AppAdditionalConfigs.kt
- app/src/main/java/dev/hossain/keepalive/ui/screen/AppActivityLogScreen.kt
- app/src/main/java/dev/hossain/keepalive/ui/screen/AppListSettings.kt