### PR TITLE
fix: Refresh installed apps list when watchlist changes

### DIFF
--- a/app/src/main/java/dev/hossain/keepalive/ui/screen/AppListSettings.kt
+++ b/app/src/main/java/dev/hossain/keepalive/ui/screen/AppListSettings.kt
@@ -105,7 +105,7 @@ fun AppListScreen(
 ) {
     val appList by viewModel.appList.observeAsState(emptyList())
     val selectedApps by viewModel.selectedApps.observeAsState(emptySet())
-    val installedApps = remember(context) { viewModel.getInstalledApps(context) }
+    val installedApps = remember(context, appList) { viewModel.getInstalledApps(context) }
     val showDialog = remember { mutableStateOf(false) }
     val showDeleteDialog = remember { mutableStateOf<AppInfo?>(null) }
     val coroutineScope = rememberCoroutineScope()


### PR DESCRIPTION
## Problem
When adding apps to the watchlist, already-added apps would still appear in the 'Add App' dialog. This happened because the installed apps list was cached and not updated when the watchlist changed.

## Solution
Added 'appList' to the remember dependency in AppListScreen so the installed apps list recomputes whenever the watchlist is modified.

### Changes
- Updated line 108 in AppListSettings.kt to include appList as a dependency

## Testing
- ✅ ktlint checks passed
- ✅ assembleDebug successful
- ✅ All unit tests passed
- ✅ No compilation errors

## Expected Behavior
Now when you add an app to the watchlist, it immediately disappears from the 'Add App' dialog list, preventing duplicate selections.