### PR TITLE
chore: Bump version to 2.11 for release

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
          * Reference: https://developer.android.com/about/versions/15/behavior-changes-15#bg-starts
          */
         targetSdk = 34 // Android 15 (Vanilla Ice Cream)
-        versionCode = 24
-        versionName = "2.10"
+        versionCode = 25
+        versionName = "2.11"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
Prepare v2.11 release with edge-to-edge support and app filtering improvements.

- versionCode: 24 → 25
- versionName: 2.10 → 2.11